### PR TITLE
Added a new batch/vep directory for the new VEP configuration we want to use in gcp-variant-transforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 ### Disclaimer
 
-This is not an official Verily product.
+This is a forked version of
+[verilylifesciences/variant-annotation](
+https://github.com/verilylifesciences/variant-annotation). The intention is to
+gradually update various pieces of this repo for variant annotation needs we
+have in [googlegenomics/gcp-variant-transforms](
+https://github.com/googlegenomics/gcp-variant-transforms) but at the same time
+provide annotation related tools/documentation that:
+  - can be used independently,
+  - are actively maintained with proper test harnesses.
+
+Any README file that has the following warning message indicates a sub-directory
+that has not been updated yet:
+
+**WARNING: Not actively maintained!**
+
+This is the list of modules that *are* actively maintained:
+* `batch/vep`
+
 
 variant-annotation
 ==================

--- a/batch/README.md
+++ b/batch/README.md
@@ -8,12 +8,21 @@ annotated on the fly with new annotation resources as they become available.)
 
 This code uses
 Ensembl's
-[Variant Effect Prediction](http://www.ensembl.org/info/docs/tools/vep/index.html) (VEP)
+[Variant Effect Prediction](
+http://www.ensembl.org/info/docs/tools/vep/index.html) (VEP)
 from McLaren et. al. 2016
-([doi:10.1186/s13059-016-0974-4](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0974-4))
-to annotate variants in a BigQuery table.
+([doi:10.1186/s13059-016-0974-4](
+https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0974-4))
+to annotate variants either in VCF files or in a BigQuery table.
 
-It is horizontally scalable due to the use
+To annotate VCF files, check the [documentation](./vep/README.md) in `vep`
+directory on how to build docker images containing VEP, how to create VEP cache
+for those images, and how to run VEP.
+
+**WARNING: The build_annotator and run_annotator pieces below are not actively
+maintained in this repo yet!**
+
+Annotating variants in BigQuery talbes is horizontally scalable due to the use
 of [dsub](https://cloud.google.com/genomics/v1alpha2/dsub). A separate instance
 of VEP is run by dsub for each shard of each of the files passed on the command
 line.  VEP is also configured to run with as many threads as the number of cores

--- a/batch/vep/Dockerfile
+++ b/batch/vep/Dockerfile
@@ -1,0 +1,61 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This is branched from batch/build_annotator/Dockerfile.vep file and is meant
+# to replace that eventually.
+#
+# Example:
+#
+# docker build . --build-arg ENSEMBL_RELEASE=91 --tag vep_91
+#
+# To run vep through containers created by this file, the VEP cache has to be
+# downloaded separately and made available through command line arguments.
+# The script for doing so is build_vep_cache.sh, see README.md for details.
+
+# Start from this container so that gcloud and all its dependencies are already
+# available.
+FROM gcr.io/cloud-builders/gcloud
+
+ARG ENSEMBL_RELEASE=91
+ARG VEP_BASE=/opt/variant_effect_predictor
+
+RUN apt-get -y update && apt-get install -y \
+    build-essential \
+    git \
+    libarchive-zip-perl \
+    libdbd-mysql-perl \
+    libdbi-perl \
+    libfile-copy-recursive-perl \
+    libhts1 \
+    libjson-perl \
+    libmodule-build-perl \
+    tabix \
+    unzip \
+    zlib1g-dev
+
+# Install VEP per the instructions at:
+# http://www.ensembl.org/info/docs/tools/vep/script/vep_download.html#installer
+RUN git clone https://github.com/Ensembl/ensembl-vep.git ${VEP_BASE}
+
+WORKDIR ${VEP_BASE}
+
+RUN git checkout release/${ENSEMBL_RELEASE}
+
+RUN perl INSTALL.pl \
+    --AUTO a \
+    --NO_UPDATE
+
+ADD run_vep.sh ${VEP_BASE}/run_vep.sh
+
+ENTRYPOINT []

--- a/batch/vep/README.md
+++ b/batch/vep/README.md
@@ -1,0 +1,109 @@
+# Annotating input files with VEP
+
+This directory includes tools and utilities for running
+[Ensembl's Variant Effect Predictor](
+https://ensembl.org/info/docs/tools/vep/index.html) (VEP) on input VCF files
+of [Variant Transforms](../README.md).
+
+## Overview
+
+With tools provided in this directory, one can:
+* Create a docker image of VEP.
+* Download and package VEP's database (a.k.a.
+[cache](https://ensembl.org/info/docs/tools/vep/script/vep_cache.html)) for
+different species, reference sequences and versions of VEP.
+* Run VEP on VCF input files and create output VCF files that are annotated.
+
+Note that, this is a useful standalone tool for running VEP in the cloud but the
+main goal is to be able to run VEP as a preprocessor through Variant Transforms
+and then import the annotated variants into BigQuery with proper handling of
+annotations.
+
+## How to create and push VEP docker images
+
+Inside this directory, run:
+
+`docker build . -t [IMAGE_TAG]`
+
+This will download the source from
+[VEP GitHub repo](https://github.com/Ensembl/ensembl-vep) and build VEP from
+that source. By default, it uses version 91 of VEP. This can be changed by
+`ENSEMBL_RELEASE` build argument, e.g.,
+
+`docker build . -t [IMAGE_TAG] --build-arg ENSEMBL_RELEASE=90`
+
+Let's say we want to push this image to the
+[Container Registry](https://cloud.google.com/container-registry/) of
+`my-project` on Google Cloud, so we can pick `[IMAGE_TAG]` as
+`gcr.io/my-project/vep_91`. Then push this image by:
+
+`gcloud docker -- push gcr.io/my-project/vep_91`
+
+**TODO**: Add `cloudbuild.yaml` files for both easy push and integration test.
+
+## How to download and package VEP databases
+
+Choose a local directory with enough space (e.g., ~20GB for homo_sapiens) to
+download and integrate different pieces of the VEP database or cache files.
+Then from within that directory run the
+[`build_vep_cache.sh`](build_vep_cache.sh) script. By default this script
+creates the database for human (homo_sapiens), referenec sequence `GRCh38`,
+and release 91 of VEP. These values can be overwritten by the following
+environment variables (note you should use the same VEP release
+that you used for creating VEP docker image above):
+
+* `VEP_SPECIES`
+* `GENOME_ASSEMBLY`
+* `ENSEMBL_RELEASE`
+
+## How to run VEP on GCP
+
+There is the helper script [`run_vep.sh`](run_vep.sh) that is added to the VEP
+docker image and can be used to run VEP. One way of running it on
+Google Cloud Platform (GCP) is through the [Pipelines API](
+https://cloud.google.com/genomics/v1alpha2/pipelines-api-command-line). For a
+sample `yaml` job description check
+[`sample_pipeline.yaml`](sample_pipeline.yaml).
+Here is a sample `gcloud` command that uses that file:
+
+```
+gcloud alpha genomics pipelines run \
+  --project my-project \
+  --pipeline-file sample_pipeline.yaml \
+  --logging gs://my_bucket/logs \
+  --inputs VCF_INFO_FILED=CSQ_RERUN
+```
+
+Note the `vep_cache_homo_sapiens_GRCh38_91.tar.gz` file that is referenced in
+the sample `yaml` file, is the output file that you get from the above database
+creation step.
+
+The [`run_vep.sh`](run_vep.sh) script relies on several environment variables
+that can be set to change the default behaviour. In the above example
+`VCF_INFO_FILED` is changed to `CSQ_RERUN` (the default is `CSQ_VT`).
+
+This is the full list of supported environment variables:
+
+* `SPECIES`: default is `homo_sapiens`
+* `GENOME_ASSEMBLY`: default is `GRCh38`
+* `NUM_FORKS`: The value to be set for
+[`--fork` option of VEP](
+http://ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_fork).
+default is 1.
+* `OTHER_VEP_OPTS`: Other options to be set for the VEP invocation, default is
+[`--everything`](
+http://ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_everything)
+* `VCF_INFO_FILED`: The name of the info field to be used for annotations,
+default is `CSQ_VT`. See
+[`--vcf_info_field`](
+http://ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_vcf_info_field)
+
+The following environment variables have to be set and point to valid storage
+locations:
+
+* `VEP_CACHE`: Where the tar.gz file, created in the above database creation
+step, is located.
+* `INPUT_FILE`: Note this can be either a VCF file or a compressed VCF file
+(`.gz` or `.bgz`). Treatment of compressed and uncompressed files is the same,
+i.e., the input file is directly fed into VEP.
+* `OUTPUT_VCF`: The name of the output file which is always a VCF file.

--- a/batch/vep/build_vep_cache.sh
+++ b/batch/vep/build_vep_cache.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This is a script for downloading VEP cache files, decompressing and placing
+# them in the appropriate directory structure that is expected by VEP script.
+# At the end, the whole structure is compressed to generate a single tar.gz
+# file that can be used in run_vep.sh invocations.
+#
+# This script creates a 'vep_cache' sub-directory and does every other file
+# operations and downloads inside that directory. The final cache file will be
+# stored in that directory as well.
+#
+# Capital letter variables refer to environment variables that can be set from
+# outside. Internal variables have small letters. All environment variables
+# have a default value as well to set up cache for homo_sapiens with reference
+# GRCh38 and release 91 of VEP.
+#
+# More details on cache files can be found here:
+# https://ensembl.org/info/docs/tools/vep/script/vep_cache.html
+
+set -euo pipefail
+
+readonly release="${ENSEMBL_RELEASE:-91}"
+readonly species="${VEP_SPECIES:-homo_sapiens}"
+readonly assembly="${GENOME_ASSEMBLY:-GRCh38}"
+readonly work_dir="vep_cache"
+
+mkdir -p "${work_dir}"
+pushd "${work_dir}"
+readonly cache_file="${species}_vep_${release}_${assembly}.tar.gz"
+readonly ftp_base="ftp://ftp.ensembl.org/pub/release-${release}"
+readonly remote_cache="${ftp_base}/variation/VEP/${cache_file}"
+echo "Downloading ${remote_cache} ..."
+curl -O "${remote_cache}"
+
+# The fasta file name depends on the species and assembly but not the version.
+# Also the first letter of the file is capital while it is small for the actual
+# cache file (above). For example: "Homo_sapiens.GRCh38.dna.toplevel.fa.gz"
+readonly fasta_file="${species^?}.${assembly}.dna.toplevel.fa.gz"
+readonly remote_fasta="${ftp_base}/fasta/homo_sapiens/dna_index/${fasta_file}"
+echo "Downloading ${remote_fasta} and its index files ..."
+curl -O "${remote_fasta}"
+curl -O "${remote_fasta}.fai"
+curl -O "${remote_fasta}.gzi"
+
+echo "Decompressing cache files ..."
+tar xzf "${cache_file}"
+
+echo "Moving fasta files to the cache structure ..."
+mv ${fasta_file}* "${species}/${release}_${assembly}"
+
+echo "Creating single tar.gz file for the whole cache ..."
+readonly output_cache="vep_cache_${species}_${assembly}_${release}.tar.gz"
+tar czf "${output_cache}" "${species}"
+if [[ -r "${output_cache}" ]]; then
+  echo "Cleaning up ..."
+  rm -rf "${species}"
+  rm -f "${cache_file}"
+fi
+popd
+
+if [[ -r "${work_dir}/${output_cache}" ]]; then
+  echo "Successfully created cache file at ${work_dir}/${output_cache}"
+else
+  echo "ERROR: Something went wrong when creating ${work_dir}/${output_cache} !"
+fi
+
+# TODO(bashir2): Experiment with the convert_cache.pl script of VEP and measure performance
+# improvements. If the change is significant then this script has to run convert_cache.pl too.
+

--- a/batch/vep/build_vep_cache.sh
+++ b/batch/vep/build_vep_cache.sh
@@ -78,6 +78,7 @@ else
   echo "ERROR: Something went wrong when creating ${work_dir}/${output_cache} !"
 fi
 
-# TODO(bashir2): Experiment with the convert_cache.pl script of VEP and measure performance
-# improvements. If the change is significant then this script has to run convert_cache.pl too.
+# TODO(bashir2): Experiment with the convert_cache.pl script of VEP and measure
+# performance improvements. If the change is significant then this script has to
+# run convert_cache.pl too.
 

--- a/batch/vep/run_vep.sh
+++ b/batch/vep/run_vep.sh
@@ -41,7 +41,7 @@ readonly species="${SPECIES:-homo_sapiens}"
 readonly assembly="${GENOME_ASSEMBLY:-GRCh38}"
 readonly fork_opt="--fork ${NUM_FORKS:-1}"
 readonly other_vep_opts="${OTHER_VEP_OPTS:---everything}"
-readonly annotation_field_name="${VCF_INFO_FILED:-CSQ_VT}"
+readonly annotation_field_name="${VCF_INFO_FILED:-CSQ}"
 
 if [[ ! -r "${VEP_CACHE:?VEP_CACHE is not set!}" ]]; then
   echo "ERRPR: Cannot read ${VEP_CACHE}"

--- a/batch/vep/run_vep.sh
+++ b/batch/vep/run_vep.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script is intended to be used in the Docker image built for VEP.
+# Note that except the single input and output files, all other arguments are
+# passed through environment variables.
+#
+# The only environment variable that has to be set is (others are optional):
+#
+# VEP_CACHE: The path of the VEP cache which is a single .tar.gz file.
+#
+# The first argument is the input file (might be a VCF or a compressed VCF) and
+# the second is the output file which is always a VCF file.
+#
+# For the full list of supported environment variables and their documentation
+# check README.md.
+# Capital letter variables refer to environment variables that can be set from
+# outside. Internal variables have small letters.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 input_file output_file"
+  exit 1
+fi
+
+readonly species="${SPECIES:-homo_sapiens}"
+readonly assembly="${GENOME_ASSEMBLY:-GRCh38}"
+readonly fork_opt="--fork ${NUM_FORKS:-1}"
+readonly other_vep_opts="${OTHER_VEP_OPTS:---everything}"
+readonly annotation_field_name="${VCF_INFO_FILED:-CSQ_VT}"
+
+if [[ ! -r "${VEP_CACHE:?VEP_CACHE is not set!}" ]]; then
+  echo "ERRPR: Cannot read ${VEP_CACHE}"
+  exit 1
+fi
+
+# Check that the input file is readable.
+readonly input_file=${1}
+if [[ ! -r "${input_file}" ]]; then
+  echo "ERRPR: Cannot read ${input_file}"
+  exit 1
+fi
+
+echo "Checking the input file at $(date)"
+ls -l "${input_file}"
+
+# Make sure output file does not exist and can be written.
+readonly output_file=${2}
+if [[ -e ${output_file} ]]; then
+  echo "ERROR: ${output_file} already exist!"
+  exit 1
+fi
+touch ${output_file}
+rm ${output_file}
+
+readonly vep_cache_dir="$(dirname ${VEP_CACHE})"
+readonly vep_cache_file="$(basename ${VEP_CACHE})"
+pushd ${vep_cache_dir}
+if [[ -d "${species}" ]]; then
+  echo "The cache is already decompressed; found ${species} at $(date)"
+else
+  echo "Decompressing the cache file ${vep_cache_file} started at $(date)"
+  tar xzvf "${vep_cache_file}"
+  if [[ ! -d "${species}" ]]; then
+    echo "Cannot find directory ${species} after decompressing ${vep_cache_file}!"
+    exit 1
+  fi
+fi
+popd
+
+readonly vep_command="./vep -i ${input_file} -o ${output_file} \
+  --dir ${vep_cache_dir} --offline --species ${species} --assembly ${assembly} \
+  --vcf --allele_number --vcf_info_field ${annotation_field_name} ${fork_opt} \
+  ${other_vep_opts}"
+echo "VEP command is: ${vep_command}"
+
+echo "Running vep started at $(date)"
+# The next line should not be quoted since we want word splitting to happen.
+${vep_command}

--- a/batch/vep/sample_pipeline.yaml
+++ b/batch/vep/sample_pipeline.yaml
@@ -1,0 +1,33 @@
+# TODO(bashir2): Update this example with v2alpha1 required changes.
+name: run-vep
+resources:
+  disks:
+    - name: datadisk
+      mountPoint: /mnt/data
+      type: PERSISTENT_HDD
+      sizeGb: 100
+  minimumCpuCores: 12
+inputParameters:
+  - name: VEP_CACHE
+    defaultValue: gs://my_bucket/vep_cache_homo_sapiens_GRCh38_91.tar.gz
+    localCopy:
+      disk: datadisk
+      path: vep_cache_91.tar.gz
+  - name: INPUT_FILE
+    defaultValue: gs://my_bucket/input.vcf
+    localCopy:
+      disk: datadisk
+      path: input.vcf
+  - name: VCF_INFO_FILED
+    defaultValue: CSQ_VT
+  - name: NUM_FORKS
+    defaultValue: "12"
+outputParameters:
+  - name: OUTPUT_FILE
+    defaultValue: gs://my_bucket/output.vcf
+    localCopy:
+      disk: datadisk
+      path: output.vcf
+docker:
+  imageName: gcr.io/my-project/vep_91
+  cmd: /opt/variant_effect_predictor/run_vep.sh ${INPUT_FILE} ${OUTPUT_FILE}


### PR DESCRIPTION
This is basically the same as [this PR of gcp-variant-transforms](https://github.com/googlegenomics/gcp-variant-transforms/pull/164), with the following notable changes:

* The ENTRYPOINT has been changed to [] (instead of ["bash"]); this is because of an issue that I discovered when using Pipelines API v2.
* The run_vep.sh script has been updated to (i) check cache before decompress and (ii) get input and output as first and second args (instead of environment variables). The reasons for these changes will become clear when I use this in VT through Pipelines API v2.
* The sample yaml file is updated accordingly.

Tested:
```
$ docker build . -f Dockerfile -t gcr.io/bashir-variant/vep_91
$ gcloud docker -- push gcr.io/bashir-variant/vep_91
$ gcloud alpha genomics pipelines run --project bashir-variant \
  --pipeline-file sample_pipeline.yaml --logging gs://test-bashir-variant/temp/runner_logs \
  --inputs VEP_CACHE=gs://bashir-variant-vep_cache/vep_cache/vep_cache_homo_sapiens_GRCh38_91.tar.gz,INPUT_FILE=gs://vep_test_files/gnomad.genomes.r2.0.2.sites.chr1_5000_lines.vcf \
  --outputs OUTPUT_FILE=gs://vep_test_files/gnomad.genomes.r2.0.2.sites.chr1_5000_lines_OUTPUT_91_RERUN.vcf
```
(also modified `sample_pipeline.yaml` to use the created image).