### PR TITLE
Fix issue ps: command not found.

### DIFF
--- a/batch/vep/Dockerfile
+++ b/batch/vep/Dockerfile
@@ -30,7 +30,7 @@ FROM gcr.io/cloud-genomics-pipelines/io
 ARG ENSEMBL_RELEASE=91
 ARG VEP_BASE=/opt/variant_effect_predictor
 
-RUN apt-get -y update && apt-get install -y \
+RUN apt-get -y update && apt-get install -y procps\
     build-essential \
     git \
     libarchive-zip-perl \


### PR DESCRIPTION
Otherwise, the VMs running VEP won't shut down when the job is cancelled.
This error occurs after updating the base image to pipelines-io.

Tested: manually ran one test.