### PR TITLE
Use VEP version as docker image tags

### DIFF
--- a/batch/vep/README.md
+++ b/batch/vep/README.md
@@ -35,9 +35,9 @@ that source. By default, it uses version 91 of VEP. This can be changed by
 Let's say we want to push this image to the
 [Container Registry](https://cloud.google.com/container-registry/) of
 `my-project` on Google Cloud, so we can pick `[IMAGE_TAG]` as
-`gcr.io/my-project/vep_91`. Then push this image by:
+`gcr.io/my-project/vep:91`. Then push this image by:
 
-`gcloud docker -- push gcr.io/my-project/vep_91`
+`gcloud docker -- push gcr.io/my-project/vep:91`
 
 **TODO**: Add `cloudbuild.yaml` files for both easy push and integration test.
 


### PR DESCRIPTION
In order to make the versioning of VEP docker images more streamlined,
we use more conventional docker image tags applied to the following
repo:

gcr.io/cloud-lifesciences/vep